### PR TITLE
Dynamo - Support writing DbValue[] as DbValueType.L

### DIFF
--- a/src/Amazon.DynamoDb.Tests/Convertors/DbConvertersTEsts.cs
+++ b/src/Amazon.DynamoDb.Tests/Convertors/DbConvertersTEsts.cs
@@ -20,5 +20,25 @@ namespace Amazon.DynamoDb
             Assert.False((bool)converter.ToObject(new DbValue(false), null));
             Assert.True((bool)converter.ToObject(new DbValue(true), null));
         }
+
+        [Fact]
+        public void SerializeDbValueListTest()
+        {
+            var converter = DbValueConverterFactory.Get(typeof(DbValue[]));
+
+            var sampleList = new DbValue[2]
+            {
+                new DbValue(true),
+                new DbValue("hello"),
+            };
+
+            var converted = converter.FromObject(sampleList, null);
+            Assert.Equal(DbValueType.L, converted.Kind);
+
+            DbValue[] backToObject = (DbValue[])converter.ToObject(converted, null);
+
+            Assert.Equal(sampleList[0].Value, backToObject[0].Value);
+            Assert.Equal(sampleList[1].Value, backToObject[1].Value);
+        }
     }
 }

--- a/src/Amazon.DynamoDb/Conversions/DbValueConverterFactory.cs
+++ b/src/Amazon.DynamoDb/Conversions/DbValueConverterFactory.cs
@@ -35,6 +35,7 @@ namespace Amazon.DynamoDb
             Add<Int64[]>(new ArrayConverter<Int64>());
             Add<float[]>(new ArrayConverter<float>());
             Add<double[]>(new ArrayConverter<double>());
+            Add<DbValue[]>(new DbValueArrayConverter());
 
             Add<HashSet<string>>(new StringHashSetConverter());
             Add<HashSet<Int16>>(new HashSetConverter<Int16>());

--- a/src/Amazon.DynamoDb/Converters/DbValueArrayConverter.cs
+++ b/src/Amazon.DynamoDb/Converters/DbValueArrayConverter.cs
@@ -1,0 +1,11 @@
+﻿using Carbon.Data;
+
+namespace Amazon.DynamoDb
+{
+    internal sealed class DbValueArrayConverter : IDbValueConverter
+    {
+        public DbValue FromObject(object value, IMember member) => new DbValue((DbValue[])value);
+
+        public object ToObject(DbValue item, IMember member) => item.ToArray<DbValue>();
+    }
+}


### PR DESCRIPTION
Due to the issue with the official Dynamo SDK's thread pool starvation issue I am trying to test out your SDK instead. First off, really well done! Almost everything worked perfectly on my first attempt, and I enjoy working with your implementation more than the official one. The only blocking issue I had was being unable to write List types properly when saving to Dynamo, although they could be read just fine. This is adding converter support for treating DbValue[] as a List type.

If you are open to these pull requests and this SDK solves our threading issues, I can follow it up with adding support for:
1) [Dynamo transactions](https://aws.amazon.com/blogs/aws/new-amazon-dynamodb-transactions/)
2) [DAX](https://aws.amazon.com/dynamodb/dax/)

Let me know what you think.