### PR TITLE
[jhw] DynamoDb Local support

### DIFF
--- a/src/Amazon.Core/Models/AwsClient.cs
+++ b/src/Amazon.Core/Models/AwsClient.cs
@@ -15,6 +15,18 @@ namespace Amazon
         private readonly AwsService service;
         protected readonly IAwsCredential credential;
 
+        public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential)
+            : this(service, region, credential, (string?)null) { }
+
+        public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential, HttpClient httpClient)
+            : this(service, region, credential, httpClient, null) { }
+
+        public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential, HttpClient httpClient, string? endpoint = null)
+            : this(service, region, credential, endpoint)
+        {
+            this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        }
+
         public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential, string? endpoint = null)
         {
             this.service    = service    ?? throw new ArgumentNullException(nameof(service));
@@ -33,15 +45,7 @@ namespace Amazon
             };
         }
 
-        public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential, HttpClient httpClient, string? endpoint = null)
-        {
-            this.service    = service ?? throw new ArgumentNullException(nameof(service));
-            Region          = region ?? throw new ArgumentNullException(nameof(region));
-            this.credential = credential ?? throw new ArgumentNullException(nameof(credential));
-            this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
-
-            Endpoint = endpoint ?? $"https://{service.Name}.{region.Name}.amazonaws.com/";
-        }
+        
 
         public string Endpoint { get; }
 

--- a/src/Amazon.Core/Models/AwsClient.cs
+++ b/src/Amazon.Core/Models/AwsClient.cs
@@ -15,13 +15,13 @@ namespace Amazon
         private readonly AwsService service;
         protected readonly IAwsCredential credential;
 
-        public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential)
+        public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential, string? endpoint = null)
         {
             this.service    = service    ?? throw new ArgumentNullException(nameof(service));
             Region          = region     ?? throw new ArgumentNullException(nameof(region));
             this.credential = credential ?? throw new ArgumentNullException(nameof(credential));
 
-            Endpoint = $"https://{service.Name}.{region.Name}.amazonaws.com/";
+            Endpoint = endpoint ?? $"https://{service.Name}.{region.Name}.amazonaws.com/";
 
             this.httpClient = new HttpClient(new HttpClientHandler {
                 AutomaticDecompression = DecompressionMethods.GZip
@@ -33,14 +33,14 @@ namespace Amazon
             };
         }
 
-        public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential, HttpClient httpClient)
+        public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential, HttpClient httpClient, string? endpoint = null)
         {
             this.service    = service ?? throw new ArgumentNullException(nameof(service));
             Region          = region ?? throw new ArgumentNullException(nameof(region));
             this.credential = credential ?? throw new ArgumentNullException(nameof(credential));
             this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
 
-            Endpoint = $"https://{service.Name}.{region.Name}.amazonaws.com/";
+            Endpoint = endpoint ?? $"https://{service.Name}.{region.Name}.amazonaws.com/";
         }
 
         public string Endpoint { get; }

--- a/src/Amazon.Core/Models/AwsClient.cs
+++ b/src/Amazon.Core/Models/AwsClient.cs
@@ -21,13 +21,13 @@ namespace Amazon
         public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential, HttpClient httpClient)
             : this(service, region, credential, httpClient, null) { }
 
-        public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential, HttpClient httpClient, string? endpoint = null)
+        public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential, HttpClient httpClient, string? endpoint)
             : this(service, region, credential, endpoint)
         {
             this.httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         }
 
-        public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential, string? endpoint = null)
+        public AwsClient(AwsService service, AwsRegion region, IAwsCredential credential, string? endpoint)
         {
             this.service    = service    ?? throw new ArgumentNullException(nameof(service));
             Region          = region     ?? throw new ArgumentNullException(nameof(region));

--- a/src/Amazon.DynamoDb/DynamoDbClient.cs
+++ b/src/Amazon.DynamoDb/DynamoDbClient.cs
@@ -17,8 +17,8 @@ namespace Amazon.DynamoDb
 
         private readonly JsonSerializerOptions SerializerOptions;
 
-        public DynamoDbClient(AwsRegion region, IAwsCredential credential)
-            : base(AwsService.DynamoDb, region, credential)
+        public DynamoDbClient(AwsRegion region, IAwsCredential credential, string? endpoint = null)
+            : base(AwsService.DynamoDb, region, credential, endpoint)
         {
             httpClient.Timeout = TimeSpan.FromSeconds(10);
 

--- a/src/Amazon.DynamoDb/DynamoDbClient.cs
+++ b/src/Amazon.DynamoDb/DynamoDbClient.cs
@@ -18,7 +18,10 @@ namespace Amazon.DynamoDb
             }
         };
 
-        public DynamoDbClient(AwsRegion region, IAwsCredential credential, string? endpoint = null)
+        public DynamoDbClient(AwsRegion region, IAwsCredential credential)
+            : this(region, credential, null) { }
+
+        public DynamoDbClient(AwsRegion region, IAwsCredential credential, string? endpoint)
             : base(AwsService.DynamoDb, region, credential, endpoint)
         {
             httpClient.Timeout = TimeSpan.FromSeconds(10);


### PR DESCRIPTION
It's possible to run DynamoDB locally (see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/DynamoDBLocal.html). Just needed to be able to pass in an override to the default Endpoint calculated for the AwsClient.

I was looking into supporting DAX with this change, but although the documentation for DAX makes it seem like "it's the same API as Dynamo, it's a write-through cache", DAX actually uses a binary protocol (CBOR) over TCP, and the C# implementation is not openly available as far as I can tell. The GO one is, and it's pretty clear this would not be a small undertaking, so I don't plan on doing it anymore. https://github.com/aws/aws-dax-go